### PR TITLE
Small modifications

### DIFF
--- a/DownPicker/DownPicker.m
+++ b/DownPicker/DownPicker.m
@@ -89,7 +89,11 @@
 -(void)doneClicked:(id) sender
 {
     [textField resignFirstResponder]; //hides the pickerView
+    if (self->textField.text.length == 0) {
+      textField.text = [dataArray objectAtIndex:0];
+    }
     [self sendActionsForControlEvents:UIControlEventValueChanged];
+  
 }
 
 - (IBAction)showPicker:(id)sender

--- a/DownPicker/DownPicker.m
+++ b/DownPicker/DownPicker.m
@@ -94,11 +94,20 @@
 
 - (IBAction)showPicker:(id)sender
 {
-    self->textField.placeholder = self->placeholderWhileSelecting;
     pickerView = [[UIPickerView alloc] init];
     pickerView.showsSelectionIndicator = YES;
     pickerView.dataSource = self;
     pickerView.delegate = self;
+    
+    //If the text field is empty show the place holder otherwise show the last selected option
+    if (self->textField.text.length == 0)
+    {
+      self->textField.placeholder = self->placeholderWhileSelecting;
+    }
+    else
+    {
+      [self->pickerView selectRow:[self->dataArray indexOfObject:self->textField.text]  inComponent:0 animated:YES];
+    }
 
     UIToolbar* toolbar = [[UIToolbar alloc] init];
     toolbar.barStyle = self->toolbarStyle;


### PR DESCRIPTION
This is a great Control for a very common issue of having a dropdown in iOS. I used it in a project, found two small things (might be more of a cosmetic stuff).
1. I wanted the picker to show a previously selected value when it popped up, so added a few lines of code to do that. Now when you use picker to select a value and then again click the text field it shows the previously selected value, instead of the first option.
2. If first time you clicked option one in the picker, and clicked done it did not reflect in the textfield, because the value change did not occur, I have added a small workaround, to select the first value if user clicks done (nothing is selected if the picker is dismissed).
