### PR TITLE
Prevents a crasher if 0 length array passed into init method

### DIFF
--- a/DownPicker/DownPicker.m
+++ b/DownPicker/DownPicker.m
@@ -135,8 +135,11 @@
 
 - (BOOL)textFieldShouldBeginEditing:(UITextField *)aTextField
 {
-    [self showPicker:aTextField];
-    return YES;
+    if ([self->dataArray count] > 0) {
+        [self showPicker:aTextField];
+        return YES;
+    }
+    return NO;
 }
 
 - (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string


### PR DESCRIPTION
Ran into an issue where I passed an empty array into Downpicker and attempting to select it crashed the app. This fixes that by prevent selection if we don't have any items in our dataArray.
