### PR TITLE
Fix for Issue #11

### DIFF
--- a/DownPicker/DownPicker.m
+++ b/DownPicker/DownPicker.m
@@ -108,7 +108,9 @@
     }
     else
     {
-      [self->pickerView selectRow:[self->dataArray indexOfObject:self->textField.text] inComponent:0 animated:YES];
+        if ([self->dataArray indexOfObject:self->textField.text] != NSNotFound) {
+            [self->pickerView selectRow:[self->dataArray indexOfObject:self->textField.text] inComponent:0 animated:YES];
+        }
     }
 
     UIToolbar* toolbar = [[UIToolbar alloc] init];


### PR DESCRIPTION
This is a quick fix for the problem I described on Issue #11. In case there is some text in the UITextField, check if these text exists in the data source array before setting the row in the picker.
