### PR TITLE
Fix problem after fixing issue #11

### DIFF
--- a/DownPicker/DownPicker.m
+++ b/DownPicker/DownPicker.m
@@ -88,9 +88,10 @@
 -(void)doneClicked:(id) sender
 {
     [textField resignFirstResponder]; //hides the pickerView
-    if (self->textField.text.length == 0) {
+    if ((self->textField.text.length == 0) || ([self->dataArray indexOfObject:self->textField.text] == NSNotFound)) {
         self->textField.text = [dataArray objectAtIndex:0];
     }
+    
     [self sendActionsForControlEvents:UIControlEventValueChanged];
 }
 


### PR DESCRIPTION
After fixing #11 I found out that, if the UITextField has text before showing the picker, if you choose the default (first) option, it didn't show up. Hope this fix it all.
