### PR TITLE
Add ability for user to not display "Cancel" button

### DIFF
--- a/Pod/Classes/DownPicker.h
+++ b/Pod/Classes/DownPicker.h
@@ -29,6 +29,8 @@
 -(id)initWithTextField:(UITextField *)tf;
 -(id)initWithTextField:(UITextField *)tf withData:(NSArray*) data;
 
+@property (nonatomic) BOOL shouldDisplayCancelButton;
+
 /**
  Sets an alternative image to be show to the right part of the textbox (assuming that showArrowImage is set to TRUE).
  @param image

--- a/Pod/Classes/DownPicker.m
+++ b/Pod/Classes/DownPicker.m
@@ -61,6 +61,8 @@
         if (data != nil) {
             [self setData: data];
         }
+        
+        self.shouldDisplayCancelButton = YES;
     }
     return self;
 }
@@ -151,12 +153,6 @@
     toolbar.barStyle = self->toolbarStyle;
     [toolbar sizeToFit];
     
-    UIBarButtonItem* cancelButton = [[UIBarButtonItem alloc]
-                                     initWithTitle:self->toolbarCancelButtonText
-                                     style:UIBarButtonItemStylePlain
-                                     target:self
-                                     action:@selector(cancelClicked:)];
-    
     //space between buttons
     UIBarButtonItem *flexibleSpace = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace
                                                                                    target:nil
@@ -168,9 +164,18 @@
                                    target:self
                                    action:@selector(doneClicked:)];
     
-    
-    
-    [toolbar setItems:[NSArray arrayWithObjects:cancelButton, flexibleSpace, doneButton, nil]];
+    if (self.shouldDisplayCancelButton) {
+        UIBarButtonItem* cancelButton = [[UIBarButtonItem alloc]
+                                         initWithTitle:self->toolbarCancelButtonText
+                                         style:UIBarButtonItemStylePlain
+                                         target:self
+                                         action:@selector(cancelClicked:)];
+        
+        [toolbar setItems:[NSArray arrayWithObjects:cancelButton, flexibleSpace, doneButton, nil]];
+    } else {
+        [toolbar setItems:[NSArray arrayWithObjects:flexibleSpace, doneButton, nil]];
+    }
+
 
     //custom input view
     textField.inputView = pickerView;

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ You can use `[UIImage imageNamed:@"yourCustomImage.png"]` to set any image in yo
 - configure (and/or localize) the placeholder text string using the `[self.downPicker setPlaceholder:NSString*]` and `[self.downPicker setPlaceholderWhileSelecting:NSString]` methods.
 - retrieve, customize and hook on the inner **UIPickerView** control using the `[self.downPicker getPickerView]` method (use at your own risk).
 - retrieve, customize and hook on the inner **UITextField** control using the `[self.downPicker getTextField]` method (use at your own risk). Remember that it's the exact same control you passed, so you might prefer to use your main reference instead.
-
+- the cancel button can be removed if the boolean flag property `shouldDisplayCancelButton` is set to `NO` after DownPicker is instantiated
 
 ## Upcoming Features
 


### PR DESCRIPTION
I've updated to 0.1.33 and noticed that there is now a "Cancel" button on the DownPicker.  However, I don't  need a "Cancel" button and added a property "shouldDisplayCancelButton" that defaults to "YES" (so that nothing changes for the normal user), but can be set to "NO" if a user doesn't want it to be shown.
