### PR TITLE
Undid that change that hits the done button

### DIFF
--- a/Pod/Classes/DownPicker.m
+++ b/Pod/Classes/DownPicker.m
@@ -197,7 +197,7 @@
 }
 
 - (void)textFieldDidEndEditing:(UITextField *)aTextField {
-    [self doneClicked:aTextField];
+    // [self doneClicked:aTextField];
     aTextField.userInteractionEnabled = YES;
     [self sendActionsForControlEvents:UIControlEventEditingDidEnd];
 }


### PR DESCRIPTION
I accidentally uncommented the line that calls the doneClicked method when the text field finishes editing.  This is a problem because it would cause it to save if you hit "Cancel" 
