### PR TITLE
DownPicker changes the value of the textField to match the currently …

### DIFF
--- a/Pod/Classes/DownPicker.h
+++ b/Pod/Classes/DownPicker.h
@@ -30,6 +30,7 @@
 -(id)initWithTextField:(UITextField *)tf withData:(NSArray*) data;
 
 @property (nonatomic) BOOL shouldDisplayCancelButton;
+@property (nonatomic) BOOL updateTextFieldValueOnlyWhenDonePressed;
 
 /**
  Sets an alternative image to be show to the right part of the textbox (assuming that showArrowImage is set to TRUE).

--- a/Pod/Classes/DownPicker.m
+++ b/Pod/Classes/DownPicker.m
@@ -16,6 +16,7 @@
 @implementation DownPicker
 {
     NSString* _previousSelectedString;
+    NSInteger _selectedRow;
 }
 
 -(id)initWithTextField:(UITextField *)tf
@@ -63,6 +64,8 @@
         }
         
         self.shouldDisplayCancelButton = YES;
+        self.updateTextFieldValueOnlyWhenDonePressed = NO;
+        _selectedRow = -1;
     }
     return self;
 }
@@ -80,7 +83,10 @@
 
 - (void)pickerView:(UIPickerView *)pickerView didSelectRow:(NSInteger)row inComponent:(NSInteger)component
 {
-    self->textField.text = [dataArray objectAtIndex:row];
+    _selectedRow = row;
+    if (!self.updateTextFieldValueOnlyWhenDonePressed) {
+        self->textField.text = [dataArray objectAtIndex:row];
+    }
 }
 
 - (NSInteger)pickerView:(UIPickerView *)pickerView numberOfRowsInComponent:(NSInteger)component;
@@ -97,6 +103,10 @@
 {
     //hides the pickerView
     [textField resignFirstResponder];
+    
+    if (self.updateTextFieldValueOnlyWhenDonePressed) {
+        self->textField.text = [dataArray objectAtIndex:_selectedRow];
+    }
     
     if (self->textField.text.length == 0 || ![self->dataArray containsObject:self->textField.text]) {
         // self->textField.text = [dataArray objectAtIndex:0];

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ That's it. You can retrieve the user's choice at any time using `self.datePicker
 ### As a Custom Control
 If you'd like to use DownPicker as a custom control instead, just instantiate the included **UIDownPicker** class programmatically and attach it to your view like any other legacy UI control:
 
+    #import "UIDownPicker.h";
+
     @interface YourViewController () {
         UIDownPicker *_dp;
     }
@@ -89,7 +91,7 @@ If you'd like to use DownPicker as a custom control instead, just instantiate th
     - (void)viewDidLoad
     {
         [super viewDidLoad];
-        self._dp = [[UIDownPicker] initWithData:yourMutableArray];
+        self._dp = [[UIDownPicker alloc] initWithData:yourMutableArray];
         [self.view addSubview:self._dp]; 
     }
     
@@ -121,6 +123,7 @@ You can use `[UIImage imageNamed:@"yourCustomImage.png"]` to set any image in yo
 - retrieve, customize and hook on the inner **UIPickerView** control using the `[self.downPicker getPickerView]` method (use at your own risk).
 - retrieve, customize and hook on the inner **UITextField** control using the `[self.downPicker getTextField]` method (use at your own risk). Remember that it's the exact same control you passed, so you might prefer to use your main reference instead.
 - the cancel button can be removed if the boolean flag property `shouldDisplayCancelButton` is set to `NO` after DownPicker is instantiated
+- the textField is updated with the value of the current scroll position only when the `Done` button is pressed if the boolean flag property `updateTextFieldValueOnlyWhenDonePressed` is set to `YES` after DownPicker is instantiated
 
 ## Upcoming Features
 


### PR DESCRIPTION
…selected option even without 'Done' being pressed. This is fine in most cases as the 'Cancel' button resets the value in the textField. However if the super view receives a 'endEditing' call then DownPicker is hidden without resetting the value in the textField. Added support for a new flag 'updateTextFieldValueOnlyWhenDonePressed'. The default value is NO so there is no change to default DownPicker functionality. But the flag can be set to YES to take advantage of the new functionality.