### PR TITLE
adds UIControlEventValueChanged when textField changes

### DIFF
--- a/Pod/Classes/DownPicker.m
+++ b/Pod/Classes/DownPicker.m
@@ -81,6 +81,7 @@
 - (void)pickerView:(UIPickerView *)pickerView didSelectRow:(NSInteger)row inComponent:(NSInteger)component
 {
     self->textField.text = [dataArray objectAtIndex:row];
+    [self sendActionsForControlEvents:UIControlEventValueChanged];
 }
 
 - (NSInteger)pickerView:(UIPickerView *)pickerView numberOfRowsInComponent:(NSInteger)component;


### PR DESCRIPTION
Currently when "UITapGestureRecognizer" is called while the DownPicker is viewed, it will update the text field but the action wont be triggered. So "sendActionsForControlEvents:UIControlEventValueChanged" is added after the text field is updated.

![older](https://cloud.githubusercontent.com/assets/9068323/23121379/22706d20-f79b-11e6-9baf-4a9c15f141e9.gif)
Prior to adding UIControlEventValueChanged
"  "
![correct_gif](https://cloud.githubusercontent.com/assets/9068323/23121234/95830a80-f79a-11e6-9b43-5179638bac6e.gif)
After adding UIControlEventValueChanged 